### PR TITLE
Update partial_about_intro; links & a couple edits

### DIFF
--- a/genevieve_client/templates/genevieve_client/partial_about_intro.html
+++ b/genevieve_client/templates/genevieve_client/partial_about_intro.html
@@ -5,7 +5,7 @@
 <ol>
   <li>
     <p>
-      <b>Genevieve matches your genome against the ClinVar database.</b>
+      <b>Genevieve matches your genome data against the ClinVar database.</b>
     </p>
     <p>
       <a href="http://www.ncbi.nlm.nih.gov/clinvar/intro/">ClinVar</a> is a
@@ -27,8 +27,9 @@
     <p>
       User-generated notes can help clarify and expand on the information
       contained in ClinVar. You can contribute to this shared understanding!
-      Genevieve's notes are public domain (CC0), and are publicly available via
-      the GenNotes server API.
+      Genevieve's notes are <a href="https://creativecommons.org/share-your-work/public-domain/cc0/">
+      public domain (CC0)</a>, and are publicly available via
+      the <a href="https://gennotes.herokuapp.com/api-guide">GenNotes server API</a>.
     </p>
   </li>
 </ol>
@@ -41,6 +42,7 @@
 
 <p>
   <b>Genevieve reports are dynamic.</b> The shared notes on Genevieve are
-  constantly subject to change, and the databases Genevieve draws upon are
-  expected to update regularly.
+  constantly subject to change, and the databases Genevieve uses are regularly
+  updated. Changes and revisions to the databases are expected and a normal
+  part of the scientific process.
 </p>


### PR DESCRIPTION
I added a link to creative commons, just for clarity it should be clear what "Public Domain"/"cc0" are for people who may have a misunderstanding of licensing.
Duplicated links in page for clarity, things link GenNotes should be linked to when first mentioned as well as the bottom.
#L8 change "genome" to "genome data" as what is delivered by each input method varies.