### PR TITLE
Clarify language re: public data

### DIFF
--- a/genevieve_client/templates/genevieve_client/partial_public_reports.html
+++ b/genevieve_client/templates/genevieve_client/partial_public_reports.html
@@ -1,4 +1,5 @@
-<h3>If Open Humans data is public, we'll make the corresponding report public.</h3>
+<h3>Genevieve is only able to process publicly shared Open Humans genome data, as such, 
+  Genevieve will make the corresponding genetic variant report public as well.</h3>
 <p>
   Data is private by default on <a href="https://www.openhumans.org/">Open
   Humans</a>, but members can opt in to publicly sharing their data if they've
@@ -12,14 +13,10 @@
   shared understanding.
 </p>
 <p>
-  To further that shared understanding, we're making corresponding Genevieve
-  reports publicly available. Genevieve is currently only available for
-  public data in Open Humans. If you change your mind and remove public status
-  on Open Humans, we'll do our best to honor that on this site as well.
-  <!-- If you make data public after we've generated a
-  report, we'll try to detect this and make the corresponding report public.
-  Also, if you change your mind and remove public status on Open Humans, we'll
-  do our best to honor that on this site as well.-->
+  To further that shared understanding, we're making the Genevieve variant
+  reports publicly available as well. Genevieve is currently only available for
+  public genome data in Open Humans. If you change your mind and remove public status
+  to your genome data on Open Humans, we will do our best to honor that on this site as well.
 </p>
 
 <h3>Example reports</h3>


### PR DESCRIPTION
Make public requirements for genetic data more clear.
Nuke hidden text as it is not relevant in deployment.