### PR TITLE
Update JQuery to `1.12.4`

### DIFF
--- a/genevieve_client/templates/base.html
+++ b/genevieve_client/templates/base.html
@@ -17,7 +17,7 @@
     <![endif]-->
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 
     <!-- Set up Bootstrap 3 using MaxCDN links. -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">


### PR DESCRIPTION
So the `1.11.x` tree was deprecated (they were at `1.11.3` the code was using `1.11.1`) for multiple remote and XSS vulnerabilities. 

The `1.12.x` will be support into the future as things move to `3.0` and is mostly patching: http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/

This *Shouldn't* break anything, but leaving as is opens a bunch of security holes.