### PR TITLE
Update libraries to current [security vulns]

### DIFF
--- a/genevieve_client/templates/base.html
+++ b/genevieve_client/templates/base.html
@@ -12,17 +12,17 @@
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 
     <!-- Set up Bootstrap 3 using MaxCDN links. -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
 


### PR DESCRIPTION
* JQuery
Bump `1.11.1` to `1.12.4`
So the `1.11.x` tree was deprecated (they were at `1.11.3` the code was using `1.11.1`) and had multiple remote and XSS vulnerabilities.
The `1.12.x` tree will be support into the future as things move to `3.0` and is mostly patching: http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/
This Shouldn't break anything, but leaving as is leaves open a bunch of security holes.

* Bootstrap 3
Bump `3.3.6` to `3.3.7`
https://blog.getbootstrap.com/2016/07/25/bootstrap-3-3-7-released/
Also `3.3.7` requires ` JQuery 1.12.4`

* html5shiv
Bump `3.7.2` to `3.7.3` for speed reasons (10x increase)
[Changelog](https://github.com/aFarkas/html5shiv/wiki):
```
v 3.3
complete refactoring by jdalton
huge performance improvement on createElement (more than 10 times faster compared to 3.2)
```

* Respond remains at `1.4.2`

This supersedes #6 as I kept digging, the hole was bigger than I thought.