### PR TITLE
Update libraries -current add integrity checking (SRI)

### DIFF
--- a/genevieve_client/templates/base.html
+++ b/genevieve_client/templates/base.html
@@ -10,19 +10,24 @@
     <link rel="icon" type="image/png" href="{% static 'images/favicon.png' %}" />
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- IE doesn't support Subresource Integrity (SRI) not adding hases
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
-      <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+      <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
 
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"
+            integrity="sha384-nvAa0+6Qg9clwYCGGPpDQLVpLNn0fRaROjHqs13t4Ggj3Ez50XnGQqc/r8MhnRDZ" crossorigin="anonymous"></script>
 
     <!-- Set up Bootstrap 3 using MaxCDN links. -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap-theme.min.css">
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" 
+          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" 
+          integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+            integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
     <link rel="stylesheet" type="text/css" href="{% static 'css/main.css' %}">
 


### PR DESCRIPTION
So this is almost identical to #7 but adds "[Subresource Integrity](https://www.srihash.org/)" checking to the `jquery` and `bootstrap` javascript. 

And can either be used in place of #7, or be rolled out after discussion.

`integrity=` are shasum's of known good versions of the `.js` files, thus preventing "MITM" and/or poisoning attacks. This is the current recommended production method for [Bootstrap](https://blog.getbootstrap.com/2016/07/25/bootstrap-3-3-7-released/#bootstrap-cdn) and [jquery](https://code.jquery.com/) for CDN deployed systems.
---
* JQuery
Bump `1.11.1` to `1.12.4`
So the `1.11.x` tree was deprecated (they were at `1.11.3` the code was using `1.11.1`) and had multiple remote and XSS vulnerabilities.
The `1.12.x` tree will be support into the future as things move to `3.0` and is mostly patching: http://blog.jquery.com/2016/01/08/jquery-2-2-and-1-12-released/
This Shouldn't break anything, but leaving as is leaves open a bunch of security holes.

* Bootstrap 3
Bump `3.3.6` to `3.3.7`
https://blog.getbootstrap.com/2016/07/25/bootstrap-3-3-7-released/
Also requires ` JQuery 1.12.4`

* html5shiv
Bump `3.7.2` to `3.7.3` for speed reasons (10x increase)
[Changelog](https://github.com/aFarkas/html5shiv/wiki):
```
v 3.3
complete refactoring by jdalton
huge performance improvement on createElement (more than 10 times faster compared to 3.2)
```

* Respond remains at `1.4.2`
---
Reason for editing: it seemed to have reused the PR #7 rather than the comment from #8.